### PR TITLE
Feature/792491 facilitate creating multiple accounts

### DIFF
--- a/gnucash/gnome-utils/dialog-account.h
+++ b/gnucash/gnome-utils/dialog-account.h
@@ -43,7 +43,7 @@
 /** @name Non-Modal
  @{ */
 
-/** Disply a window for editing the attributes of an existing account.
+/** Display a window for editing the attributes of an existing account.
  *
  *  @param parent The widget on which to parent the dialog.
  *
@@ -53,7 +53,7 @@
 void gnc_ui_edit_account_window (GtkWindow *parent, Account *account);
 
 
-/** Disply a window for creating a new account.  This function will
+/** Display a window for creating a new account.  This function will
  *  also initially set the parent account of the new account to what
  *  the caller specified.  The user is free, however, to choose any
  *  parent account they wish.
@@ -71,7 +71,7 @@ void gnc_ui_new_account_window (GtkWindow *parent,
                                 QofBook *book, Account *parent_acct);
 
 
-/** Disply a window for creating a new account.  This function will
+/** Display a window for creating a new account.  This function will
  *  restrict the available account type values to the list specified
  *  by the caller.
  *

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="account_cascade_color_dialog">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Cascade Account Color</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can_focus">False</property>
@@ -148,9 +151,6 @@
       <action-widget response="-6">cancelbutton3</action-widget>
       <action-widget response="-5">okbutton3</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkDialog" id="account_delete_dialog">
     <property name="can_focus">False</property>
@@ -159,6 +159,9 @@
     <property name="modal">True</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox100">
         <property name="visible">True</property>
@@ -226,6 +229,113 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="subaccounts">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="label101">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Sub-accounts&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkGrid" id="grid101">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="column_spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="label8477420">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">15</property>
+                        <property name="label" translatable="yes">This account contains sub-accounts. What would you like to do with these sub-accounts?</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="sa_mrb">
+                        <property name="label" translatable="yes">_Move to:</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">15</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="gppat_populate_trans_mas_list" swapped="no"/>
+                        <signal name="toggled" handler="gppat_set_insensitive_iff_rb_active" object="subaccount_trans" swapped="yes"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="sa_drb">
+                        <property name="label" translatable="yes">Delete all _subaccounts</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">15</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">sa_mrb</property>
+                        <signal name="toggled" handler="gppat_set_insensitive_iff_rb_active" object="sa_mas_hbox" swapped="yes"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="sa_mas_hbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -346,113 +456,6 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="subaccounts">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="hexpand">True</property>
-                <property name="orientation">vertical</property>
-                <child>
-                  <object class="GtkLabel" id="label101">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Sub-accounts&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkGrid" id="grid101">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="column_spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="label8477420">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">15</property>
-                        <property name="label" translatable="yes">This account contains sub-accounts. What would you like to do with these sub-accounts?</property>
-                        <property name="wrap">True</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
-                        <property name="width">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="sa_mrb">
-                        <property name="label" translatable="yes">_Move to:</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">15</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="gppat_populate_trans_mas_list" swapped="no"/>
-                        <signal name="toggled" handler="gppat_set_insensitive_iff_rb_active" object="subaccount_trans" swapped="yes"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="sa_drb">
-                        <property name="label" translatable="yes">Delete all _subaccounts</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">15</property>
-                        <property name="use_underline">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">sa_mrb</property>
-                        <signal name="toggled" handler="gppat_set_insensitive_iff_rb_active" object="sa_mas_hbox" swapped="yes"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
-                        <property name="width">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="sa_mas_hbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -591,12 +594,14 @@
     </action-widgets>
   </object>
   <object class="GtkDialog" id="account_filter_by_dialog">
-    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
     <property name="title" translatable="yes">Filter By...</property>
     <property name="type_hint">dialog</property>
     <signal name="response" handler="gppat_filter_response_cb" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox200">
         <property name="visible">True</property>
@@ -778,25 +783,6 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="show_zero">
-                    <property name="label" translatable="yes">Show _zero total accounts</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Show accounts which have a zero total value.</property>
-                    <property name="halign">start</property>
-                    <property name="margin_left">12</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="gppat_filter_show_zero_toggled_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkCheckButton" id="show_unused">
                     <property name="label" translatable="yes">Show _unused accounts</property>
                     <property name="visible">True</property>
@@ -808,6 +794,25 @@
                     <property name="use_underline">True</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="gppat_filter_show_unused_toggled_cb" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="show_zero">
+                    <property name="label" translatable="yes">Show _zero total accounts</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Show accounts which have a zero total value.</property>
+                    <property name="halign">start</property>
+                    <property name="margin_left">12</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="gppat_filter_show_zero_toggled_cb" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -893,6 +898,9 @@
     <property name="window_position">center</property>
     <property name="type_hint">dialog</property>
     <signal name="destroy" handler="gnc_account_window_destroy_cb" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox300">
         <property name="visible">True</property>
@@ -956,6 +964,23 @@
             <property name="fill">True</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="continue_button">
+            <property name="label" translatable="yes">C_reate another account</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="halign">end</property>
+            <property name="use_underline">True</property>
+            <property name="image_position">right</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">-1</property>
           </packing>
         </child>
         <child>
@@ -1624,13 +1649,15 @@
     <property name="page_increment">100</property>
   </object>
   <object class="GtkDialog" id="account_renumber_dialog">
-    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
     <property name="title" translatable="yes">Renumber sub-accounts</property>
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <signal name="response" handler="gnc_account_renumber_response_cb" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox400">
         <property name="visible">True</property>


### PR DESCRIPTION
Fixes #5 

Resolves Bug-792491 Facilitate creating multiple accounts.

A toggle button is added above the OK and Cancel buttons located near the bottom of the page.  The feature utilizes the OK button functionality while creating an account, and creates a new UI to allow the user to continue creating accounts.  The toggle button is only displayed on the 'New Account' dialog and is hidden on the 'Edit Account' dialog.

![screenshot at 2018-11-08 11-52-48](https://user-images.githubusercontent.com/35235905/48215088-7b93b780-e34f-11e8-8c67-df6c51cfb201.png)