### PR TITLE
Added Scroll Window to search critera to fix window clipping.

### DIFF
--- a/gnucash/gtkbuilder/dialog-search.glade
+++ b/gnucash/gtkbuilder/dialog-search.glade
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="search_dialog">
     <property name="can_focus">False</property>
+    <property name="default_height">400</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
@@ -235,36 +239,56 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkGrid" id="criteria_table">
+                      <object class="GtkScrolledWindow">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">3</property>
+                        <property name="can_focus">True</property>
+                        <property name="margin_bottom">56</property>
+                        <property name="hscrollbar_policy">never</property>
+                        <property name="shadow_type">etched-in</property>
+                        <property name="min_content_height">5</property>
+                        <property name="propagate_natural_height">True</property>
                         <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
+                          <object class="GtkViewport">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="shadow_type">etched-in</property>
+                            <child>
+                              <object class="GtkGrid" id="criteria_table">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="border_width">3</property>
+                                <property name="row_spacing">5</property>
+                                <property name="baseline_row">2</property>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
                         </child>
                       </object>
                       <packing>


### PR DESCRIPTION
Added Scroll Window to glade search template to avoid overflow of search criteria. 
Maximum amount of items displayed is 5, before a scroll bar appears to accommodate for additional search criteria.